### PR TITLE
Document manual GH workflow scope auth step

### DIFF
--- a/install/git-initial-config.sh
+++ b/install/git-initial-config.sh
@@ -2,6 +2,7 @@
 gh auth login
 gh config set git_protocol https
 gh auth setup-git
+gh auth status
 
 # Configure gpg-agent with extended cache timeout
 # so that I don't have to enter my passphrase every time I commit

--- a/install/manual-installs.md
+++ b/install/manual-installs.md
@@ -26,6 +26,9 @@
    https://stackoverflow.com/questions/4220416/can-i-specify-multiple-users-for-myself-in-gitconfig
 - Lastpass
    - Install the Safari/Chrome extension(s)
+- GitHub CLI additional scope (interactive browser/device auth)
+  - `gh auth refresh -h github.com -s workflow`
+  - `gh auth status`
 
 
 ## Later


### PR DESCRIPTION
## Summary
- Keep `install/git-initial-config.sh` non-interactive by avoiding `gh auth refresh -h github.com -s workflow` in the script.
- Add the workflow-scope refresh and `gh auth status` to `install/manual-installs.md` as an explicit manual step.
- Retain `gh auth status` in initial git setup to verify authentication state.

## Test plan
- [x] Run `install/git-initial-config.sh` and confirm it does not prompt for workflow scope authorization.
- [x] Run `gh auth refresh -h github.com -s workflow` manually and complete browser/device auth.
- [x] Run `gh auth status` and verify expected scopes are present.

Made with [Cursor](https://cursor.com)