### PR TITLE
Activate mise in zsh shell config

### DIFF
--- a/.zsh/config.sh
+++ b/.zsh/config.sh
@@ -8,6 +8,9 @@
 # # first `brew install direnv`, then
 # eval "$(direnv hook zsh)"
 
+# Activate mise (tool version manager)
+eval "$(/Users/samjewell/.local/bin/mise activate zsh)"
+
 # Add Go to PATH
 export GOPATH=$HOME/go
 # Note: GOROOT should not be set manually - Go handles this automatically


### PR DESCRIPTION
## Summary
- Adds `mise activate zsh` to `.zsh/config.sh` so mise is available in every shell session
- Uses the full path to the mise binary since `~/.local/bin` isn't on `PATH` yet when `config.sh` is sourced

## Test plan
- [ ] Open a new terminal and verify `mise` commands work
- [ ] Confirm tool versions managed by mise are picked up correctly

Made with [Cursor](https://cursor.com)