### PR TITLE
Update zsh GPG environment for reliable pinentry

### DIFF
--- a/.zsh/config.sh
+++ b/.zsh/config.sh
@@ -47,6 +47,10 @@ export GF_FEATURE_TOGGLES_ENABLE="tableNextGen,queryLibrary,sqlExpressions,sqlEx
 # Enable console logging for analytics events
 export GF_ANALYTICS_BROWSER_CONSOLE_REPORTER=true
 
+# Keep GPG signing stable across terminal/context changes.
+export GPG_TTY=$(tty)
+gpg-connect-agent updatestartuptty /bye >/dev/null 2>&1
+
 PROMPT='%{$fg[yellow]%}%D{%L:%M:%S} '$PROMPT
 
 # # Switch off spotlight indexing


### PR DESCRIPTION
## Summary
- Export `GPG_TTY` in zsh shell config so gpg-agent tracks the active terminal.
- Call `gpg-connect-agent updatestartuptty` during shell init to reduce `No pinentry` signing failures after context changes.

## Test plan
- [x] Validate only `.zsh/config.sh` changed.
- [ ] Reload shell with `source ~/.zshrc`.
- [ ] Restart agent once with `gpgconf --kill gpg-agent`.
- [ ] Create a signed commit and confirm signing succeeds.

Made with [Cursor](https://cursor.com)