### PR TITLE
feat: add LaunchAgent to re-apply keyboard repeat settings at login

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Check to make sure you aren't going to overwrite (clobber) anything, then add sy
 `ln -s dotfiles/.pryrc .pryrc`
 `ln -s dotfiles/.gitignore_global .gitignore_global`
 
+Symlink and load the LaunchAgents (re-applies keyboard repeat settings at every login, needed on macOS Sequoia):
+`ln -sf ~/dotfiles/osx/launch-agents/com.samjewell.keyboard-repeat.plist ~/Library/LaunchAgents/com.samjewell.keyboard-repeat.plist`
+`launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.samjewell.keyboard-repeat.plist`
+
 Launch Sourcetree by right-clicking, and then choose "Open"
 That way you can open it, even when Apple doesn't trust it.
 

--- a/osx/launch-agents/com.samjewell.keyboard-repeat.plist
+++ b/osx/launch-agents/com.samjewell.keyboard-repeat.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.samjewell.keyboard-repeat</string>
+
+    <!--
+        Re-applies keyboard repeat settings at every login.
+
+        macOS Sequoia resets the com.apple.Accessibility domain values during
+        login, overriding any NSGlobalDomain keyboard repeat settings. The sleep
+        gives system daemons time to finish their own writes before we overwrite.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>
+            sleep 3;
+            defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false;
+            defaults write NSGlobalDomain KeyRepeat -int 1;
+            defaults write NSGlobalDomain InitialKeyRepeat -int 10;
+            defaults write com.apple.Accessibility KeyRepeatEnabled -bool false;
+            defaults write com.apple.Accessibility KeyRepeatInterval -float 0.016666666;
+            defaults write com.apple.Accessibility KeyRepeatDelay -float 0.166666667
+        </string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- macOS Sequoia resets `com.apple.Accessibility` keyboard repeat values during login, reverting the fast repeat rate set in `defaults.sh`
- Adds a LaunchAgent (`com.samjewell.keyboard-repeat`) that re-applies all keyboard repeat defaults at every GUI login
- Includes a `sleep 3` so the agent runs after system daemons have finished their own writes to the Accessibility domain
- Updates `README.md` with the symlink + load commands needed on a fresh machine

## Setup (for a fresh install)

```bash
ln -sf ~/dotfiles/osx/launch-agents/com.samjewell.keyboard-repeat.plist ~/Library/LaunchAgents/com.samjewell.keyboard-repeat.plist
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.samjewell.keyboard-repeat.plist
```

## Test plan

- [ ] Log out and back in
- [ ] Wait ~5 seconds after login
- [ ] Hold a key in a text editor and confirm rapid repeat is active

Made with [Cursor](https://cursor.com)