### PR TITLE
Add Ghostty config mirroring my iTerm2 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Check to make sure you aren't going to overwrite (clobber) anything, then add sy
 `ln -s dotfiles/.pryrc .pryrc`
 `ln -s dotfiles/.gitignore_global .gitignore_global`
 
+If you want Ghostty to pick up the colour scheme exported from iTerm, symlink the whole `ghostty` directory into `~/.config`:
+`mkdir -p ~/.config && ln -s ~/dotfiles/ghostty ~/.config/ghostty`
+The theme file lives at `ghostty/themes/sj-iterm-2026` and is activated by the single `theme = sj-iterm-2026` line in `ghostty/config`. Note that the colours are Display P3 values, so they require `window-colorspace = display-p3` (set in the theme) to render identically to iTerm — this is macOS-only.
+
 Launch Sourcetree by right-clicking, and then choose "Open"
 That way you can open it, even when Apple doesn't trust it.
 

--- a/ghostty/config
+++ b/ghostty/config
@@ -1,0 +1,16 @@
+theme = sj-iterm-2026
+
+# Match my iTerm Default profile (Settings -> Profiles -> Text):
+#   - Monaco 12pt (iTerm "Font: Monaco / Regular / 12")
+#   - bold text uses the bright palette variant (iTerm: "Use bright colors for bold")
+#   - thicker font strokes (Ghostty's default rendering on macOS came out thinner than
+#     iTerm's "Thin strokes: On Retina Displays" did, so opt back into thickening here)
+font-family = Monaco
+font-size = 12
+bold-color = bright
+font-thicken = true
+
+# iTerm-style "selection automatically copies to clipboard". Must be `clipboard`
+# (not `true`) on macOS — `true` only writes to the selection clipboard, which
+# on macOS is middle-click-only and doesn't make cmd-V work.
+copy-on-select = clipboard

--- a/ghostty/themes/sj-iterm-2026
+++ b/ghostty/themes/sj-iterm-2026
@@ -1,0 +1,33 @@
+# sj-iterm-2026 — exported from iTerm2 on 11 May 2026.
+#
+# All colours are Display P3 values taken straight from the iTerm export,
+# so window-colorspace must be set to display-p3 for the rendered output
+# to match iTerm. (display-p3 is macOS-only; on Linux these will still
+# render, just interpreted as sRGB.)
+window-colorspace = display-p3
+
+background = #000000
+foreground = #c7c7c7
+
+cursor-color = #c7c7c7
+cursor-text = #ffffff
+
+selection-background = #c7ddfc
+selection-foreground = #000000
+
+palette = 0=#000000
+palette = 1=#b93119
+palette = 2=#52bf37
+palette = 3=#c7c43e
+palette = 4=#0d24bf
+palette = 5=#ba3ec1
+palette = 6=#54c2c6
+palette = 7=#c7c7c7
+palette = 8=#686868
+palette = 9=#f0776d
+palette = 10=#8df77a
+palette = 11=#fefc7f
+palette = 12=#6a71f7
+palette = 13=#f07ff8
+palette = 14=#8efafd
+palette = 15=#ffffff


### PR DESCRIPTION
## Why

Ghostty is supposed to render faster than iTerm2 and I'm not using any iTerm-specific features, so I want to give it a real run as my daily terminal. This commit gets it set up to look and behave the same as my current iTerm so the swap is invisible to my fingers.

## What

- **`ghostty/themes/sj-iterm-2026`** — 16-colour ANSI palette plus cursor / selection / fg / bg, taken straight from a Display-P3 iTerm `.itermcolors` export. The theme sets `window-colorspace = display-p3` so the hex codes render identically to iTerm on macOS (no sRGB conversion / loss).
- **`ghostty/config`** — references the theme, plus a few non-colour preferences chosen to match how I had iTerm rendering:
  - `font-family = Monaco`, `font-size = 12`
  - `bold-color = bright` (iTerm's "Use bright colors for bold")
  - `font-thicken = true` (Ghostty's macOS default came out thinner than iTerm's "Thin strokes: On Retina Displays" rendering, side-by-side)
  - `copy-on-select = clipboard` (iTerm's "Selection automatically copies to clipboard"; `clipboard` rather than `true` because on macOS `true` only writes to the middle-click selection clipboard)
- **`README.md`** — symlink instructions for `~/.config/ghostty`.

## Test plan

- [x] Side-by-side compared Ghostty vs iTerm with the same prompt — colours, weight, and contrast match.
- [x] Verified `cmd-shift-,` reload in Ghostty applies the theme without restart.
- [x] Verified `copy-on-select = clipboard` lets selected text paste into other apps via `cmd-V`.
- [ ] Run as my primary terminal for a week and see if the speed claim holds up.

Made with [Cursor](https://cursor.com)