### PR TITLE
Move gcom completions out of aliases.sh

### DIFF
--- a/.zsh/aliases.sh
+++ b/.zsh/aliases.sh
@@ -46,11 +46,6 @@ alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 # Add kubectl completions
 source <(kubectl completion zsh)
 
-# GCom completions
-source <(gcom --autocompletion=zsh)
-source <(gcom-dev --autocompletion=zsh)
-source <(gcom-ops --autocompletion=zsh)
-
 alias k="kubectl"
 
 # Github aliases, inspired by git aliases from OhMyZsh plugin


### PR DESCRIPTION
## Why

The auto-completion lines I added in 92ce4fc were sourced from `aliases.sh`, but the `gcom*` wrapper functions they depend on are defined in `secrets.sh` — which `.zshrc` sources *after* `aliases.sh`. Result on every shell startup:

```
/Users/samjewell/dotfiles/.zsh/aliases.sh:50: command not found: gcom
/Users/samjewell/dotfiles/.zsh/aliases.sh:51: command not found: gcom-dev
/Users/samjewell/dotfiles/.zsh/aliases.sh:52: command not found: gcom-ops
```

…and the completions never actually loaded.

## What

Remove the three `source <(gcom* ...)` lines from `aliases.sh`. They have a new home in `secrets.sh` (gitignored), immediately after the function definitions where load ordering is guaranteed and the env-suffixed variants don't end up in the public repo.

## Test plan

- [x] Open a fresh shell — no "command not found" errors.
- [x] `which gcom` returns the function definition.
- [x] Tab-completion on `gcom <TAB>` works (validates that the source line ran).

Made with [Cursor](https://cursor.com)