### PR TITLE
Add npm/pnpm supply-chain security configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Check to make sure you aren't going to overwrite (clobber) anything, then add sy
 `ln -s dotfiles/.irbrc .irbrc`
 `ln -s dotfiles/.pryrc .pryrc`
 `ln -s dotfiles/.gitignore_global .gitignore_global`
+`ln -s dotfiles/.npmrc .npmrc`
+`mkdir -p ~/Library/Preferences/pnpm && ln -s ~/dotfiles/pnpm/rc ~/Library/Preferences/pnpm/rc`
 
 If you want Ghostty to pick up the colour scheme exported from iTerm, symlink the whole `ghostty` directory into `~/.config`:
 `mkdir -p ~/.config && ln -s ~/dotfiles/ghostty ~/.config/ghostty`

--- a/pnpm/rc
+++ b/pnpm/rc
@@ -1,0 +1,1 @@
+minimum-release-age=10080


### PR DESCRIPTION
## Summary
- Track `.npmrc` and `pnpm/rc` in dotfiles, symlinked to `~/.npmrc` and `~/Library/Preferences/pnpm/rc`
- Set `ignore-scripts=true` and `min-release-age=7` (days) for npm
- Set `minimum-release-age=10080` (7 days in minutes) for pnpm
- Update README with symlink instructions for both files

Motivated by the [HN discussion](https://news.ycombinator.com/item?id=48100706) on dependency cooldowns as a supply-chain attack mitigation.


Made with [Cursor](https://cursor.com)