### PR TITLE
Clean up brew install lists and drop stale python@3.9

### DIFF
--- a/install/brew-cask.sh
+++ b/install/brew-cask.sh
@@ -9,22 +9,24 @@ apps=(
   dropbox
   flycut # clipboard manager
   gcx # Grafana Cloud CLI
+  ghostty # terminal (replaces iterm2)
   google-chrome
   google-cloud-sdk
-  iterm2
+  # iterm2 # replaced by ghostty
   # I don't think I trust this - it can read every keypress
   # karabiner-elements # keyboard remapping - F5 to dictation on magic keyboard 1st gen
   keybase
   kindle
-  lastpass
+  # lastpass
   miro
+  orbstack # Docker/Linux VMs (replaces Docker for Mac)
   # postico # Postgres only
   rectangle
-  redisinsight
+  # redisinsight
   slack
   sourcetree
   # visual-studio-code # Get the Arm64 Insiders build instead
-  valentina-studio # Both Postgres and MySQL I think
+  # valentina-studio # Both Postgres and MySQL I think
   zoom
   # anaconda
   # docker # Get the Apple M1 tech preview build instead

--- a/install/brew.sh
+++ b/install/brew.sh
@@ -19,7 +19,7 @@ arm_packages=(
   go
   gpg # keys
   grafana-cloud-agent
-  grafana/grafana/grafana-assistant
+  # grafana/grafana/grafana-assistant
   gron # grep for JSON
   jq
   jsonnet
@@ -27,12 +27,11 @@ arm_packages=(
   # k3d # lightweight k8s distro, but don't need both this and minikube
   kubectl # K8s client
   # istioctl
-  mysql-client@5.7
+  # mysql-client@5.7
   node@20 # could install yarn instead, if v14 not needed
   pgrep # will also install pkill
   pinentry-mac # for gpg signing of commits
   pipx # for installing Python CLI tools
-  python@3.9 # installed by awscli anyway
   ripgrep # fast grep
   # ruby@2.7 # system ruby is 2.6
   sl # train animation for Ezra

--- a/install/manual-installs.md
+++ b/install/manual-installs.md
@@ -5,11 +5,8 @@
    - Add `export EDITOR='code -w'` to the .zshrc file
    - Add sublime-text keybindings (extension)
    - Log into my Github Account
-- iterm2
-   - Configure navigating and deleting whole words:
-     https://medium.com/@jonnyhaynes/jump-forwards-backwards-and-delete-a-word-in-iterm2-on-mac-os-43821511f0a
-- docker for mac:
-   - the Apple M1 tech preview build at https://docs.docker.com/docker-for-mac/apple-m1/ 
+- ghostty (terminal) - installed via `brew-cask.sh`
+- OrbStack (Docker/Linux VMs, replaces Docker for Mac) - installed via `brew-cask.sh`
 - Set an unique name for each Mac, in Sys Prefs: Sharing
 - Google Cloud SDK: cask or https://cloud.google.com/sdk/docs/install, then:
   - `gcloud auth login`


### PR DESCRIPTION
## Summary
- Swap `iterm2` for `ghostty` and add `orbstack` (replacing Docker for Mac) in the cask list; drop `lastpass`, `redisinsight`, and `valentina-studio` casks no longer in use
- Remove `install/brew.sh`'s `python@3.9` entry — it's now uninstalled and unused since `uv` handles Python versioning for project work
- Comment out `grafana/grafana/grafana-assistant` and `mysql-client@5.7` in `install/brew.sh`
- Update `install/manual-installs.md` to reflect the ghostty/orbstack switch and drop stale iterm2/Docker-for-Mac notes

## Test plan
- [x] Reviewed diff for correctness
- [ ] Re-run `install/brew.sh` and `install/brew-cask.sh` on a fresh machine (or dry-run) to confirm no breakage

Made with [Cursor](https://cursor.com)