### PR TITLE
Add uv/awscli/prometheus, fix stale brew.sh entries

### DIFF
--- a/install/brew-cask.sh
+++ b/install/brew-cask.sh
@@ -8,10 +8,9 @@ apps=(
   claude-code
   dropbox
   flycut # clipboard manager
-  gcx # Grafana Cloud CLI
+  gcloud-cli
   ghostty # terminal (replaces iterm2)
   google-chrome
-  google-cloud-sdk
   # iterm2 # replaced by ghostty
   # I don't think I trust this - it can read every keypress
   # karabiner-elements # keyboard remapping - F5 to dictation on magic keyboard 1st gen

--- a/install/brew.sh
+++ b/install/brew.sh
@@ -5,7 +5,7 @@
 
 # Install packages
 arm_packages=(
-  # awscli # has a LOT of dependencies, inc Python and SQLite
+  awscli
   betterleaks
   cowsay # with Ezra
   derailed/k9s/k9s # K8s interactive terminal application
@@ -17,26 +17,28 @@ arm_packages=(
   gitleaks
   gh # github CLI tool
   go
+  go-jsonnet
   gpg # keys
-  grafana-cloud-agent
+  grafana-alloy
   # grafana/grafana/grafana-assistant
+  grafana/grafana/gcx # Grafana Cloud CLI
   gron # grep for JSON
   jq
-  jsonnet
   jsonnet-bundler
   # k3d # lightweight k8s distro, but don't need both this and minikube
   kubectl # K8s client
   # istioctl
   # mysql-client@5.7
-  node@20 # could install yarn instead, if v14 not needed
+  node
   pgrep # will also install pkill
   pinentry-mac # for gpg signing of commits
-  pipx # for installing Python CLI tools
+  prometheus
   ripgrep # fast grep
   # ruby@2.7 # system ruby is 2.6
   sl # train animation for Ezra
   trash
   trufflehog
+  uv # Python package/version manager
   # ansible
   # chromedriver
   # circleci
@@ -50,9 +52,6 @@ arm_packages=(
   # mas # installs apps from the App Store, via the command-line
   # minikube # Don't need both this and k3d
   # postgresql # Run through Docker instead?
-  # pypy3
-  # python # MacOS python doesn't include pip, but this does. But postpone, and use Conda instead?
-  # redis # Run through Docker instead?
   # sqlite
   # tanka
   # terraform


### PR DESCRIPTION
## Summary
- Add `uv`, uncomment `awscli`, add `prometheus` -- all already in daily use but missing from the setup script
- Fix `grafana-cloud-agent` (disabled upstream, install would fail) -> `grafana-alloy`
- Fix `jsonnet` -> `go-jsonnet` to match what's actually installed (they conflict)
- Drop the `node@20` pin for unversioned `node`, matching reality
- Move `gcx` from brew-cask.sh (it's a formula tap, not a cask) into brew.sh; rename `google-cloud-sdk` -> `gcloud-cli` (legacy alias) in brew-cask.sh
- Drop `pipx` (already partially broken -- stale interpreter paths; `uv` covers this now) and remove stale `pypy3`/`python`/`redis` placeholder comments

## Test plan
- [x] Reviewed diff for correctness against a full audit of `brew leaves` / `brew list --cask` vs the scripts
- [ ] Re-run `install/brew.sh` and `install/brew-cask.sh` on a fresh machine (or dry-run) to confirm no breakage

Made with [Cursor](https://cursor.com)